### PR TITLE
fix: add horizontal scrolling

### DIFF
--- a/lib/src/outer_sheath_view.dart
+++ b/lib/src/outer_sheath_view.dart
@@ -10,11 +10,23 @@ class OuterSheathView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ListView(
+      // this allows for horizontal scrolling
+      scrollDirection: Axis.horizontal,
       children: [
-        Align(
-          alignment: Alignment.topLeft,
-          child: RemovableGroundsForm(
-            data: removableGroundsData,
+        SizedBox(
+          height: MediaQuery.of(context).size.height,
+          // this width should match width of widest widget
+          width: 1200,
+          // this ListView allows for vertical scrolling by default
+          child: ListView(
+            children: [
+              Align(
+                alignment: Alignment.topLeft,
+                child: RemovableGroundsForm(
+                  data: removableGroundsData,
+                ),
+              ),
+            ],
           ),
         ),
       ],


### PR DESCRIPTION
This branch fixes horizontal overflow issues of OuterSheathView. The same solution can be utilized in other views as well. Some comments are provided in code to explain what's going on.

Width is currently hard-coded. This could be made smarter by calculating width of rendered components, and matching the max width for SizedBox's width attribute.

closes #32 