### PR TITLE
Added initialization for nulls to be displayed as 0.0 for current cells

### DIFF
--- a/lib/src/data/cell.dart
+++ b/lib/src/data/cell.dart
@@ -14,7 +14,7 @@ class Cell extends StatefulWidget {
 }
 
 class _CellState extends State<Cell> {
-  late dynamic value = widget.initialValue ?? "hei";
+  late dynamic value = widget.initialValue;
   TextEditingController? _controller;
 
   String periodToComma(dynamic text) {
@@ -45,7 +45,7 @@ class _CellState extends State<Cell> {
   void initState() {
     super.initState();
     if (widget.type == CellType.input) {
-      final text = periodToComma(widget.initialValue);
+      final text = periodToComma(widget.initialValue ?? 0.0 );
       _controller = TextEditingController(
         text: text,
       );
@@ -72,7 +72,7 @@ class _CellState extends State<Cell> {
             ),
           ),
           child: Center(
-            child: Text(value),
+            child: Text(value?.toString() ?? "0.0"),
           ),
         );
       case CellType.column:
@@ -86,7 +86,7 @@ class _CellState extends State<Cell> {
             ),
           ),
           child: Center(
-            child: Text(value),
+            child: Text(value?.toString() ?? "0.0"),
           ),
         );
       case CellType.empty:

--- a/lib/src/data/output_cell.dart
+++ b/lib/src/data/output_cell.dart
@@ -21,7 +21,7 @@ class OutputCell extends StatelessWidget {
       ),
       child: Center(
         child: Text(
-          getter().toString(),
+          getter()?.toString() ?? "0.0"
         ),
       ),
     );

--- a/lib/src/forms/foundation_type_and_floors_form.dart
+++ b/lib/src/forms/foundation_type_and_floors_form.dart
@@ -106,70 +106,70 @@ class FoundationTypeAndFloorsForm extends StatelessWidget {
               initialValue: 'Perustuksen pinta-ala (m2)'),
           Cell(
             type: CellType.input,
-            initialValue: state.falsePlinth?.area ?? 0.0,
+            initialValue: state.falsePlinth?.area,
             setter: (value) =>
                 foundationsBloc.add(FalsePlinthAreaChanged(value)),
           ),
           Cell(
             type: CellType.input,
-            initialValue: state.crawlSpace?.area ?? 0.0,
+            initialValue: state.crawlSpace?.area,
             setter: (value) =>
                 foundationsBloc.add(CrawlSpaceAreaChanged(value)),
           ),
           Cell(
             type: CellType.input,
-            initialValue: state.shallow?.area ?? 0.0,
+            initialValue: state.shallow?.area,
             setter: (value) => foundationsBloc.add(ShallowAreaChanged(value)),
           ),
           Cell(
             type: CellType.input,
-            initialValue: state.pillar?.area ?? 0.0,
+            initialValue: state.pillar?.area,
             setter: (value) => foundationsBloc.add(PillarAreaChanged(value)),
           ),
           Cell(
             type: CellType.input,
-            initialValue: state.hollowCoreSlab?.area ?? 0.0,
+            initialValue: state.hollowCoreSlab?.area,
             setter: (value) =>
                 foundationsBloc.add(HollowCoreSlabAreaChanged(value)),
           ),
           OutputCell(
-            getter: () => state.area ?? 0.0,
+            getter: () => state.area,
           ),
           Cell(
               type: CellType.header,
               initialValue: 'Perustuksen pinta-ala (m2)'),
           Cell(
             type: CellType.input,
-            initialValue: state.falsePlinth?.circumference ?? 0.0,
+            initialValue: state.falsePlinth?.circumference,
             setter: (value) =>
                 foundationsBloc.add(FalsePlinthCircumferenceChanged(value)),
           ),
           Cell(
             type: CellType.input,
-            initialValue: state.crawlSpace?.circumference ?? 0.0,
+            initialValue: state.crawlSpace?.circumference,
             setter: (value) =>
                 foundationsBloc.add(CrawlSpaceCircumferenceChanged(value)),
           ),
           Cell(
             type: CellType.input,
-            initialValue: state.shallow?.circumference ?? 0.0,
+            initialValue: state.shallow?.circumference,
             setter: (value) =>
                 foundationsBloc.add(ShallowCircumferenceChanged(value)),
           ),
           Cell(
             type: CellType.input,
-            initialValue: state.pillar?.circumference ?? 0.0,
+            initialValue: state.pillar?.circumference,
             setter: (value) =>
                 foundationsBloc.add(PillarCircumferenceChanged(value)),
           ),
           Cell(
             type: CellType.input,
-            initialValue: state.hollowCoreSlab?.circumference ?? 0.0,
+            initialValue: state.hollowCoreSlab?.circumference,
             setter: (value) =>
                 foundationsBloc.add(HollowCoreSlabCircumferenceChanged(value)),
           ),
           OutputCell(
-            getter: () => state.circumference ?? 0.0,
+            getter: () => state.circumference,
           ),
         ],
       );


### PR DESCRIPTION
I’ve updated the initialization so that current null values are displayed as 0.0, while still remaining null in the code. This change was straightforward to implement. However, future cells will not automatically display as 0.0 unless the same adjustment is manually added to the parameters.

Please take a look at the changed and let me know whether this was the intended way to handle this. 

Another possible way to handle this has to deal with changing the calculation module and adding a bit of code there, but I'm unsure whether I should be touching it yet 🤔

(Also let me know if I did this pull request stuff correctly)

closes #49 