### PR TITLE
formatting inputs for when boolean percentage is true, uses whole numbers such as 10 or 20% for input

### DIFF
--- a/lib/src/data/cell.dart
+++ b/lib/src/data/cell.dart
@@ -41,10 +41,16 @@ class _CellState extends State<Cell> {
   late dynamic value = widget.initialValue;
   TextEditingController? _controller;
 
-  String periodToComma(dynamic text) {
-    return text.toString().replaceFirst('.', ',');
+  // Convert value to a percentage string (e.g., 0.2 -> 20%)
+  String formatValueForDisplay(dynamic value) {
+    if (widget.percentage && value is num) {
+      return "${(value * 100).toInt()}%"; // Convert to integer percentage for display
+    } else {
+      return value?.toString() ?? "0.0";
+    }
   }
 
+  // Convert the input to a decimal value for storage (e.g., 20% -> 0.2)
   void handleChange(String value) {
     print('Controller value: ${_controller?.text}');
     var formattedValue = '0';
@@ -78,7 +84,8 @@ class _CellState extends State<Cell> {
   void initState() {
     super.initState();
     if (widget.type == CellType.input) {
-      final text = periodToComma(widget.initialValue ?? 0.0);
+      // Initialize the controller with the formatted initial value for percentage display
+      final text = formatValueForDisplay(widget.initialValue ?? 0.0);
       _controller = TextEditingController(text: text);
     }
   }
@@ -89,6 +96,7 @@ class _CellState extends State<Cell> {
     _controller?.dispose();
   }
 
+  // Returns a widget depending on the type of the cell
   Widget type() {
     switch (widget.type) {
       case CellType.input:


### PR DESCRIPTION
added functionality for cells (input) to be of value percentage for writing percentages as '10%' or '10'. created functionality for how these should be calculated when used. (Do not take into account that output fields are showing 0.1 and 0.2 instead of 10% and 20%, it's not about them. This is about input cells)

Sadly current branch does not have input fields with percentages yet, so have to show how it's used in floor-materials-form-26 branch.

![kuva](https://github.com/user-attachments/assets/8ad7ca4f-0330-4013-b669-d2b98b15ab09)


closes #96 