### PR TITLE
UX inputcell 87

### DIFF
--- a/lib/src/data/input_cell.dart
+++ b/lib/src/data/input_cell.dart
@@ -94,7 +94,6 @@ class _InputCellState extends State<InputCell> {
     _focusNode.addListener(() {
       if (!_focusNode.hasFocus) {
         formatDisplayedValue();
-        logger.d({_controller.text});
       }
     });
   }


### PR DESCRIPTION
This branch gets rid of cells being formatted while user is editing them. They are formatted only after cell loses focus, to add missing trailing zero, add percentage, etc. It feels pretty good now imo. Also selects all text when selecting a cell.

~~However, I think percentage cells work incorrectly. Perhaps something was messed up by this branch, but I don't think they were fully correct anyways. This branch is up for grabs for anyone who knows what's going on with formatDisplayedValue() function.~~

~~Idk what this is supposed to do and I'm afraid of it.~~
```dart
if (widget.percentage) {
  return '${(widget.initialValue! * 100).toStringAsFixed(0)}%';
}
```

~~pls send help~~

I think everything kind of works now, but I have become blind to my own doings so pls test. Integer, percentage, double should all be good now.

closes #87 when finished